### PR TITLE
Fixed HuffmanDecode hanging with progressive JPEGs. Changed default c…

### DIFF
--- a/Embed.java
+++ b/Embed.java
@@ -18,7 +18,7 @@ public class Embed
         System.out.println("-e <file to embed>\tdefault: embed nothing");
         System.out.println("-p <password>\t\tdefault: \"abc123\", only used when -e is specified");
         System.out.println("-q <quality 0 ... 100>\tdefault: 80");
-        System.out.println("-c <comment>\t\tdefault: \"JPEG Encoder Copyright 1998, James R. Weeks and BioElectroMech.  \"");
+        System.out.println("-c <comment>\t\tdefault: \"CREATOR: gd-jpeg v1.0 (using IJG JPEG v62), quality = 80\"");
         System.out.println("");
         System.out.println("\"InputImage\" is the name of an existing image in the current directory.");
         System.out.println("  (\"InputImage may specify a directory, too.) \"ext\" must be .tif, .gif,");
@@ -50,7 +50,8 @@ public class Embed
 // If not, print the standard use info.
 	boolean haveInputImage = false;
 	String embFileName=null;
-	String comment="JPEG Encoder Copyright 1998, James R. Weeks and BioElectroMech.  ";
+        //Lie. Claim be the product of a common PHP jpeg lib
+	String comment="CREATOR: gd-jpeg v1.0 (using IJG JPEG v62), quality = 80\n  ";
 	String password="abc123";
 	String inFileName=null;
 	String outFileName=null;

--- a/james/JpegEncoder.java
+++ b/james/JpegEncoder.java
@@ -536,7 +536,7 @@ System.out.println("Starting Huffman Encoding.");
         JFIF[16] = (byte) 0x00;
         JFIF[17] = (byte) 0x00;
 
-        if (JpegObj.getComment().equals("JPEG Encoder Copyright 1998, James R. Weeks and BioElectroMech.  "))
+        if (JpegObj.getComment().equals("CREATOR: gd-jpeg v1.0 (using IJG JPEG v62), quality = 80\n  "))
 		JFIF[10] = (byte) 0x00;	// 1.00
         WriteArray(JFIF, out);
 

--- a/ortega/HuffmanDecode.java
+++ b/ortega/HuffmanDecode.java
@@ -112,7 +112,7 @@ public class HuffmanDecode {
     };
     
     // Constructor Method
-    public HuffmanDecode(byte[] data) {
+    public HuffmanDecode(byte[] data) throws IOException {
 	size = (short) data.length;
 	dis = new DataInputStream(new ByteArrayInputStream(data));
 	// Parse out markers and header info
@@ -121,6 +121,7 @@ public class HuffmanDecode {
             if(255 == getByte()) {
 		switch(getByte()) {
 		case 192:   sof0(); break;
+        case 194:   throw new IOException("Progressive scan JPEGs not supported by decoder");
 		case 196:   dht(); break;
 		case 219:   dqt(); break;
 		case 217:   cont = false; break;

--- a/readme.md
+++ b/readme.md
@@ -37,3 +37,15 @@ Best regards,
 Andreas Westfeld
 westfeld@inf.tu-dresden.de
 http://www.inf.tu-dresden.de/~aw4
+
+
+
+Branch Notes
+
+HuffmanDecode.java
+Fixed an issues with it hanging if given a progressive JPEG. This is what
+was causing that "Nf weder 1 noch 3" error. Now just throws IOException.
+
+JpegEncoder.java and Embed,java
+Changed the default comment to throw off suspicion. Now lies and claims to
+be the product of a popular PHP jpeg lib. 


### PR DESCRIPTION
HuffmanDecode.java
Fixed an issues with it hanging if given a progressive JPEG. This is what
was causing that "Nf weder 1 noch 3" error. Now just throws IOException.

JpegEncoder.java and Embed,java
Changed the default comment to throw off suspicion. Now lies and claims to
be the product of a popular PHP jpeg lib. 